### PR TITLE
Support new vim-lsp

### DIFF
--- a/autoload/lsp/tinysnippet.vim
+++ b/autoload/lsp/tinysnippet.vim
@@ -1,22 +1,10 @@
 let s:pattern_of_tabstop_or_placeholder = '\(\${\d\{-\}:\w\{-\}}\|\$\d\)'
 
-function! lsp#tinysnippet#move_to_top_of_new_text() abort
-    try
-        let l:user_data = json_decode(v:completed_item['user_data'])
-    catch
-        return
-    endtry
-
-    if type(l:user_data) != type({})
-        return
-    endif
-
-    let l:position = l:user_data['vim-lsp/textEdit']['range']['start']
-    let l:row = l:position['line'] + 1
-    let l:col = l:position['character'] + 1
-
-    call cursor(l:row, l:col)
+function! lsp#tinysnippet#expand(params) abort
+    execute printf('normal! i%s', a:params.snippet)
+    execute printf('normal! %sh', strlen(a:params.snippet) - 1)
 endfunction
+
 
 """ {{{ LSP形式のタブストップ($1)かプレースホルダ(${1:xxx}, $1)までジャンプする
 function! lsp#tinysnippet#select_next() abort

--- a/plugin/lsp/tinysnippet.vim
+++ b/plugin/lsp/tinysnippet.vim
@@ -4,6 +4,7 @@ endif
 let g:vim_lsp_tiny_snippet_loaded = 1
 
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#tinysnippet#lsp_get_snippet_supported_capability')])
+let g:lsp_snippet_expand = [function('lsp#tinysnippet#expand')]
 
 function! lsp#tinysnippet#lsp_get_snippet_supported_capability(server_info) abort
     let l:snippet_supported_capability = lsp#default_get_supported_capabilities(a:server_info)
@@ -13,9 +14,4 @@ function! lsp#tinysnippet#lsp_get_snippet_supported_capability(server_info) abor
 
     return l:snippet_supported_capability
 endfunction
-
-augroup tiny_snippet_init
-    autocmd!
-    autocmd User lsp_complete_done call lsp#tinysnippet#move_to_top_of_new_text()
-augroup END
 


### PR DESCRIPTION
vim-lsp 側の補完周りに変更が入ったため、追従の PR を作成しました。

vim-lsp が snippet を展開する場合に `g:lsp_snippet_expand = [function(...)]` を設定しておくと自動で呼んでくれるように変更が入ったため、autocmd 周りを除去しております。
